### PR TITLE
Fixes bug generating getter/setter for properties starting with underscore 

### DIFF
--- a/org.pdtextensions.core/src/org/pdtextensions/core/util/Inflector.java
+++ b/org.pdtextensions.core/src/org/pdtextensions/core/util/Inflector.java
@@ -142,8 +142,10 @@ public class Inflector
         String parts[] = name.split("_"); 
         String string = ""; 
         for (String part : parts) { 
-            string += part.substring(0, 1).toUpperCase(); 
-            string += part.substring(1).toLowerCase(); 
+        	if (!part.equals("")) {
+	            string += part.substring(0, 1).toUpperCase(); 
+	            string += part.substring(1).toLowerCase(); 
+        	}
         }
         
         return string; 


### PR DESCRIPTION
In order to fix the issue https://github.com/pdt-eg/Core-Plugin/issues/14

Possible test to add:

```
public void testGetSetterNameWithUnderscores() {
    IField mockedField = mock(IField.class);
    when(mockedField.getElementName()).thenReturn("$_name_var");

    assertEquals("setNameVar", GetterSetterUtil.getSetterName(mockedField));
}
```
