### PR TITLE
Hide global use statements on outline

### DIFF
--- a/org.pdtextensions.core.ui/plugin.xml
+++ b/org.pdtextensions.core.ui/plugin.xml
@@ -257,4 +257,14 @@
             class="org.pdtextensions.core.ui.quickassist.AssignToLocalQuickAssistProcessor">
       </quickAssistProcessor>
    </extension>
+   <extension
+         point="org.eclipse.dltk.ui.dltkElementFilters">
+      <filter
+            class="org.pdtextensions.core.ui.filter.UseStatementsFilter"
+            enabled="true"
+            id="org.pdtextensions.ui.outline.useStatmentsFilter"
+            name="Hide use statements"
+            targetId="org.eclipse.php.ui.OutlinePage">
+      </filter>
+   </extension>
 </plugin>

--- a/org.pdtextensions.core.ui/src/org/pdtextensions/core/ui/filter/UseStatementsFilter.java
+++ b/org.pdtextensions.core.ui/src/org/pdtextensions/core/ui/filter/UseStatementsFilter.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2012 The PDT Extension Group (https://github.com/pdt-eg)
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.pdtextensions.core.ui.filter;
+
+import org.eclipse.dltk.core.ISourceModule;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.php.internal.ui.outline.PHPOutlineContentProvider.UseStatementsNode;
+
+public class UseStatementsFilter extends ViewerFilter {
+
+	public UseStatementsFilter() {
+	}
+
+
+	@Override
+	public boolean select(Viewer viewer, Object parentElement, Object element) {
+		if (!(parentElement instanceof ISourceModule) || !(element instanceof UseStatementsNode)) {
+			return true;
+		}
+
+		return false;
+	}
+
+}


### PR DESCRIPTION
Global "use statements" element is hidden by default in outline page.

"import declarations" section off course is still visible.
