### PR TITLE
Avoid "No PHP exe configured" when PHP exe is available via ext.p.

### DIFF
--- a/org.pdtextensions.core/src/org/pdtextensions/core/launch/environment/AbstractEnvironmentFactory.java
+++ b/org.pdtextensions.core/src/org/pdtextensions/core/launch/environment/AbstractEnvironmentFactory.java
@@ -3,6 +3,8 @@ package org.pdtextensions.core.launch.environment;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.php.internal.ui.preferences.util.PreferencesSupport;
+import org.pdtextensions.core.exception.ExecutableNotFoundException;
+import org.pdtextensions.core.util.LaunchUtil;
 
 @SuppressWarnings("restriction")
 public abstract class AbstractEnvironmentFactory implements EnvironmentFactory {
@@ -16,7 +18,18 @@ public abstract class AbstractEnvironmentFactory implements EnvironmentFactory {
 		String useProjectPhar = prefSupport.getPreferencesValue(getUseProjectKey(), null, project);
 		String systemPhar = prefSupport.getPreferencesValue(getScriptKey(), null, project);
 		
-		if (executable != null && executable.length() > 0) {
+		if (executable == null || executable.isEmpty()) {
+			// the user has not set any preference for PHP executable yet,
+			// so try finding any PHP executable, e.g. contributed via the
+			// phpExe extension point
+			try {
+				executable = LaunchUtil.getPHPExecutable();
+			} catch (ExecutableNotFoundException e) {
+				// no php exe found - executable will remain null
+			}
+		}
+		
+		if (executable != null && !executable.isEmpty()) {
 			if (useProjectPhar != null && "true".equals(useProjectPhar) || (systemPhar == null || systemPhar.length() == 0) ) {
 				return getProjectEnvironment(executable);
 			}


### PR DESCRIPTION
If the user hasn't selected a PHP executable in the Composer's
preference page, then creating a composer project fails with "No PHP
executable configured" error. However, they are might be PHP executable
configured by another plugin using the org.eclipse.php.debug.core.phpExe
extension point. In this case any of these PHP executables can do the
job and this error should not be displayed.

The environment factory should try to get any PHP executable if one is
not available by just reading the preferences.
