### PR TITLE
Give preference to CLI type when determining the default PHP exe

### DIFF
--- a/org.pdtextensions.core/src/org/pdtextensions/core/util/LaunchUtil.java
+++ b/org.pdtextensions.core/src/org/pdtextensions/core/util/LaunchUtil.java
@@ -1,11 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2012 The PDT Extension Group (https://github.com/pdt-eg)
+ * Copyright (c) 2012, 2014 The PDT Extension Group (https://github.com/pdt-eg)
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  ******************************************************************************/
 package org.pdtextensions.core.util;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import org.eclipse.php.internal.debug.core.preferences.PHPexeItem;
 import org.eclipse.php.internal.debug.core.preferences.PHPexes;
@@ -23,25 +26,56 @@ public class LaunchUtil {
 	}
 	
 	public static String getPHPExecutable(String debugger) throws ExecutableNotFoundException {
-
-		PHPexeItem phpExe = null;
+		// find the default PHP executable
+		PHPexeItem defaultPhpExe = getDefaultPHPExeItem(debugger);
 		
-		phpExe = PHPexes.getInstance().getDefaultItem(debugger);
+		// check if the SAPI type is CLI
+		if (PHPexeItem.SAPI_CLI.equals(defaultPhpExe.getSapiType())) {
+			// if yes - return it 
+			return defaultPhpExe.getExecutable().toString();
+		}
 		
+		// otherwise try to find a PHP CLI executable
+		PHPexeItem[] cliItems = PHPexes.getInstance().getCLIItems();
+		if (cliItems.length == 0) {
+			// if no PHP CLI executable then return the default one
+			return defaultPhpExe.getExecutable().toString();
+		}
+		
+		// sort the PHP CLI executable by version
+		SortedMap<String, PHPexeItem> map = new TreeMap<String, PHPexeItem>();
+		for (PHPexeItem item : cliItems) {
+			map.put(item.getVersion(), item);
+		}
+		
+		// check if there is a PHP CLI executable with the same version as the default PHP executable
+		PHPexeItem phpExe = map.get(defaultPhpExe.getVersion());
 		if (phpExe != null) {
 			return phpExe.getExecutable().toString();
+		}
+		
+		// otherwise return the PHP CLI executable with the greatest version
+		phpExe = map.get(map.lastKey());
+		return phpExe.getExecutable().toString();
+	}
+	
+	private static PHPexeItem getDefaultPHPExeItem(String debugger) throws ExecutableNotFoundException {
+		PHPexeItem phpExe = PHPexes.getInstance().getDefaultItem(debugger);
+		
+		if (phpExe != null) {
+			return phpExe;
 		}
 		
 		phpExe = PHPexes.getInstance().getDefaultItem(XDebugCommunicationDaemon.XDEBUG_DEBUGGER_ID);
 		
 		if (phpExe != null) {
-			return phpExe.getExecutable().toString();
+			return phpExe;
 		}
 		
 		phpExe = PHPexes.getInstance().getDefaultItem(DebuggerCommunicationDaemon.ZEND_DEBUGGER_ID);
 
 		if (phpExe != null) {
-			return phpExe.getExecutable().toString();
+			return phpExe;
 		}
 
 		throw new ExecutableNotFoundException("Unable to find PHP executable");


### PR DESCRIPTION
With PR #85 the environment factory started to check the
org.eclipse.php.debug.core.phpExe extension point for PHP executable if
one is not defined in the preferences.

There might be the case that there are PHP executables with various SAPI
types (CGI and CLI) registered in the extension point. Therefore, the
environment factory may pick up a CGI executable, which may cause
problems for the tools (like Composer) with "Maximum execution time of
30 seconds exceeded".

This patch modified the LaunchUtil.getPHPExecutable() method to give
preference to CLI executables.
