### PR TITLE
ScriptLauncher should add LD_LIBRARY_PATH to the environment

### DIFF
--- a/org.pdtextensions.core/src/org/pdtextensions/core/launch/ScriptLauncher.java
+++ b/org.pdtextensions.core/src/org/pdtextensions/core/launch/ScriptLauncher.java
@@ -1,12 +1,16 @@
 package org.pdtextensions.core.launch;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.ExecuteException;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.php.internal.debug.core.launching.PHPLaunchUtilities;
 import org.pdtextensions.core.launch.environment.Environment;
 import org.pdtextensions.core.launch.execution.ExecutionResponseListener;
 import org.pdtextensions.core.launch.execution.ScriptExecutor;
@@ -68,7 +72,10 @@ public class ScriptLauncher {
 			executor.addResponseListener(listener);
 		}
 		
-		executor.execute(cmd);
+		Map<String, String> env = new HashMap<String, String>(System.getenv());
+		PHPLaunchUtilities.appendLibrarySearchPathEnv(env, new File(cmd.getExecutable()).getParentFile());
+		
+		executor.execute(cmd, env);
 	}
 	
 	public void abort() {

--- a/org.pdtextensions.core/src/org/pdtextensions/core/launch/execution/ScriptExecutor.java
+++ b/org.pdtextensions.core/src/org/pdtextensions/core/launch/execution/ScriptExecutor.java
@@ -3,6 +3,7 @@ package org.pdtextensions.core.launch.execution;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.exec.CommandLine;
@@ -121,7 +122,10 @@ public class ScriptExecutor {
 	}
 
 	public void execute(CommandLine cmd) {
-		
+		execute(cmd, null);
+	}
+
+	public void execute(CommandLine cmd, Map<String, String> env) {
 		try {
 			for (ExecutionResponseListener handler : listeners) {
 				handler.executionAboutToStart();
@@ -129,7 +133,7 @@ public class ScriptExecutor {
 			
 			Logger.debug("executing command using executable: " + cmd.getExecutable());
 			executor.setExitValue(0);
-			executor.execute(cmd, handler);
+			executor.execute(cmd, env, handler);
 			
 			for (ExecutionResponseListener handler : listeners) {
 				handler.executionStarted();


### PR DESCRIPTION
This helps running correctly those PHP executable which pack the
required native libraries for the included PHP modules, so it is not
necessary to install them on the system.

For example, Zend Studio provides such built-in PHP executables and it
is having the LD_LIBRARY_PATH is important for running them correctly.

This patch uses the PHPLaunchUtilities.appendLibrarySearchPathEnv()
utility method from PDT to append the correct env var (LD_LIBRARY_PATH
for Linux, DYLD_FALLBACK_LIBRARY_PATH for Mac OS X) to the external
process.