### PR TITLE
fix compilation to support latest PDT 6.0 snapshot

### DIFF
--- a/org.pdtextensions.core/src/org/pdtextensions/core/util/PDTFormatterUtils.java
+++ b/org.pdtextensions.core/src/org/pdtextensions/core/util/PDTFormatterUtils.java
@@ -67,9 +67,9 @@ public class PDTFormatterUtils {
 	}
 
 	public static ICodeFormattingProcessor createCodeFormatter(IDocument document, IRegion region,
-			PHPVersion phpVersion, boolean useShortTags) throws Exception {
+			PHPVersion phpVersion, boolean useASPTags, boolean useShortTags) throws Exception {
 		if (getFormatterFactory() != null) {
-			return formatterFactory.getCodeFormattingProcessor(document, phpVersion, useShortTags, region);
+			return formatterFactory.getCodeFormattingProcessor(document, phpVersion, useASPTags, useShortTags, region);
 		}
 
 		return new DefaultCodeFormattingProcessor(new HashMap());
@@ -79,7 +79,7 @@ public class PDTFormatterUtils {
 		DocumentChange documentChange = new DocumentChange("Format region", document);
 		try {
 			ICodeFormattingProcessor formatter = createCodeFormatter(document, region,
-					ProjectOptions.getPHPVersion(project), ProjectOptions.useShortTags(project));
+					ProjectOptions.getPHPVersion(project), ProjectOptions.isSupportingASPTags(project), ProjectOptions.useShortTags(project));
 
 			documentChange.setEdit(formatter.getTextEdits());
 			if (document != null) {


### PR DESCRIPTION
Hi Dawid,
could you please merge this patch to fix compilation failure after that PDT patch https://git.eclipse.org/r/#/c/119830/ was merged?

Thank you! ;)

Thierry.
NB: since the PDT interface IFormatterProcessorFactory was modified, could you change the pom.xml to force PDT >= 6.0 in future "pdt extensions" releases?
